### PR TITLE
escape shell meta characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,10 @@ SESSION_USER_DATA = "SESSION_USER_DATA"
 
 let _store
 
-const WHITESPACE_PATTERN = / /g
-
-function escapeWhitepsaceInDirectory(path) {
+function escapeShellMeta(path) {
   // only support linux and mac style now
-  return path.replace(WHITESPACE_PATTERN,"\\ ")
+  return path.replace(/(?=[!"#$&'()*,;<=>?[\]^`{|}~ ])/g, '\\')
 }
-
 
 function sendSessionData(uid, data, escaped) {
   return ((dispatch, getState) => {
@@ -50,7 +47,7 @@ exports.onRendererWindow = (window) => {
           rewritePath = hyperConfig.hyperDropFile.pathRewriter(file.path,hyperConfig)
         }
         else {
-          rewritePath = escapeWhitepsaceInDirectory(file.path)
+          rewritePath = escapeShellMeta(file.path)
         }
         sendSessionData(null, rewritePath)
         break


### PR DESCRIPTION
It would be useful to escape additional troublesome characters from pathnames, besides just whitespace. I kept running into issues navigating my Dropbox folder, b/c Dropbox *insists* on calling it "Dropbox (Personal)", and because whitespace is being escaped, you can't simply put the dropped path in quotes.

Some googling lead me to use this rewriter:

```JS
    hyperDropFile:{
      pathRewriter:(path,hyperConfig)=>{
        return path.replace(/(?=[!"#$&'()*,;<=>?[\]^`{|}~ ])/g, '\\');
      }
    }
```
Reference:
https://stackoverflow.com/questions/22872974/javascript-regex-to-escape-parentheses-and-spaces
https://unix.stackexchange.com/questions/347332/what-characters-need-to-be-escaped-in-files-without-quotes